### PR TITLE
Refactor Point Operation algorithms.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,6 @@ nightly = ["subtle/nightly"]
 u64_backend = []
 default = ["u64_backend"]
 
-[badges]
-travis-ci = { repository = "dusk-network/dusk-network/Dusk-Zerocaf", branch = "master" }
-codecov = { repository = "dusk-network/dusk-network/Dusk-Zerocaf", branch = "master", service = "github" }
-is-it-maintained-issue-resolution = { repository = "dusk-network/dusk-network/Dusk-Zerocaf" }
-is-it-maintained-open-issues = { repository = "dusk-network/dusk-network/Dusk-Zerocaf" }
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerocaf"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Luke Pearson <luke@dusk.network>", 
            "CPerezz <carlos@dusk.network>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Luke Pearson <luke@dusk.network>", 
            "CPerezz <carlos@dusk.network>"]
 readme = "README.md"
+documentation = "https://dusk-network.github.io/dusk-zerocaf/zerocaf/index.html"
 repository = "https://github.com/dusk-network/Dusk-Zerocaf"
 keywords = ["cryptography", "ristretto", "doppio-curve", "ECC"]
 categories =["Algorithms", "Cryptography", "Development tools"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ description = "A pure-Rust implementation of elliptic curve operations over the 
 exclude = [
     "**/.gitignore",
     ".gitignore",
-    "tools",
-    "sage_codes"
+    "**/tools",
+    "**/sage_codes"
 
 ]
 license = "MIT"

--- a/benchmarks/dusk_benchmarks.rs
+++ b/benchmarks/dusk_benchmarks.rs
@@ -8,6 +8,7 @@ use criterion::{Criterion, Benchmark};
 
 use zerocaf::backend::u64::{scalar, field};
 use zerocaf::edwards::EdwardsPoint;
+#[allow(unused_imports)]
 use zerocaf::traits::Identity;
 
 

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -583,7 +583,7 @@ impl FieldElement {
         #[inline]
         fn phase2(r: &FieldElement, k: &u64) -> FieldElement {
             let mut rr = r.clone();
-            let p = &constants::FIELD_L;
+            let _p = &constants::FIELD_L;
 
             for _i in 0..(k-253) {
                 match rr.is_even() {
@@ -598,7 +598,7 @@ impl FieldElement {
             rr 
         }
 
-        let (mut r, mut z) = phase1(&self.clone());
+        let (mut r, z) = phase1(&self.clone());
 
         r = phase2(&r, &z);
 
@@ -708,7 +708,9 @@ impl FieldElement {
 pub mod tests {
 
     use crate::backend::u64::field::FieldElement;
+    #[allow(unused_imports)]
     use crate::backend::u64::constants as constants;
+    #[allow(unused_imports)]
     use crate::scalar::Ristretto255Scalar;
 
     /// Bytes representation of `-1 (mod l) = 7237005577332262213973186563042994240857116359379907606001950938285454250988`
@@ -799,7 +801,7 @@ pub mod tests {
     }
 
     #[test]
-    fn add_L() {
+    fn add_field_l() {
         let a: FieldElement = FieldElement([2, 0, 0, 0 ,0]);
         let res = &a + &constants::FIELD_L;
         for i in 0..5 {
@@ -832,7 +834,7 @@ pub mod tests {
     }
 
     #[test]
-    fn subtract_L() {
+    fn subtract_field_l() {
         let a: FieldElement = FieldElement([2, 0, 0, 0 ,0]);
         let res = &a - &constants::FIELD_L;
         for i in 0..5 {

--- a/src/backend/u64/scalar.rs
+++ b/src/backend/u64/scalar.rs
@@ -167,7 +167,7 @@ fn m(x: u64, y: u64) -> u128 {
 /// u64 * u64 = u128 macro multiply helper
 macro_rules! m {
     ($x:expr, $y:expr) => {
-        ($x as u128 * $y as u128) 
+        $x as u128 * $y as u128 
     }
 }
 
@@ -219,7 +219,7 @@ impl Scalar {
     }
 
     /// Reduce a 64 byte / 512 bit scalar mod l
-    pub fn from_bytes_wide(bytes: &[u8; 64]) -> Scalar {
+    pub fn from_bytes_wide(_bytes: &[u8; 64]) -> Scalar {
        // We could provide 512 bit scalar support using Montgomery Reduction. 
        // But first we need to finnish the 256-bit implementation.
        unimplemented!()

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,5 @@
 //! Contains the curve-constants needed by the different algorithm implementations.
 
-use crate::scalar::Scalar;
 use crate::field::FieldElement;
 
 /// Edwards `a` variable value = `-1 (mod l)` equals:

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 //! Edwards Point operation implementations and definitions.
 //! Encoding/decoding processes implementation 
 //! and support for all kind of interactions with them.
@@ -126,10 +127,13 @@ pub struct EdwardsPoint {
 
 impl Debug for EdwardsPoint {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "X: {:?}\n", &self.X);
-        write!(f, "Y: {:?}\n", &self.Y);
-        write!(f, "Z: {:?}\n", &self.Z);
-        write!(f, "T: {:?}\n", &self.T)
+        write!(f, "
+        EdwardsPoint {{
+            X: {:?},
+            Y: {:?},
+            Z: {:?},
+            T: {:?}
+        }};", self.X, self.Y, self.Z, self.T)
     }
 }
 /*
@@ -367,7 +371,7 @@ impl EdwardsPoint {
     }
 
     /// Compute ([2^k] P)
-    pub fn mul_by_pow_2(&self, k: u32) -> EdwardsPoint {
+    pub fn mul_by_pow_2(&self, _k: u32) -> EdwardsPoint {
         unimplemented!()
     }
 }
@@ -376,7 +380,6 @@ impl EdwardsPoint {
 /// Also used to check the correctness of the transformation functions.
 pub mod tests {
     use super::*;
-    use constants::*;
 
     pub static P1: EdwardsPoint = EdwardsPoint {
         X: FieldElement([23, 0, 0, 0, 0]),

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -450,15 +450,4 @@ pub mod tests {
         
         assert!(res == P3);
     }
-
-    #[test]
-    fn double_and_add() {
-        let res1 = &P1 * &Scalar::from(&2u8);
-
-        let res2 = &P1 + &P1;
-
-        let res3 = &P1.double();
-
-        println!("{:?}\n{:?}\n{:?}", res1, res2, res3);
-    }
 }

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -274,14 +274,20 @@ impl EdwardsPoint {
     /// http://eprint.iacr.org/2008/522, Section 3.1.
     /// Cost: 4M+ 4S+ 1D
     pub fn double(&self) -> EdwardsPoint {
-        let tw_fr = FieldElement::from(&24u8);
-        let a = FieldElement::minus_one();
+        // This algorithm will be using point addition as base
+        // until we find out what problem are we experiencing
+        // with the doubling formulae on Extended Coords.
+        //
+        // TODO: Fix this as prio to reduce ops number.
 
-        let A = self.X.square();
-        let B = self.Y.square();
-        let C = &tw_fr * &self.Z.square();
-        let D = &a * &A;
-        let E = &((&(&self.X + &self.Y).square()) - &A) - &B;
+        /*let two: FieldElement = FieldElement::from(&2u8);
+
+        let A = &self.X * &self.X;
+        let B = &self.Y * &self.Y;
+        let C = &two * &(&self.Z * &self.Z);
+        // a = -1
+        let D = -&A;
+        let E = &(&(&(&self.X + &self.Y) * &(&self.X + &self.Y)) - &A) - &B;
         let G = &D + &B;
         let F = &G - &C;
         let H = &D - &B;
@@ -290,9 +296,10 @@ impl EdwardsPoint {
             X: &E * &F,
             Y: &G * &H,
             Z: &F * &G,
-            T: &E * &H,
-        }
+            T: &E * &H
+        }*/
 
+        self + self
     }
 
     /// Return the `EdwardsPoint` with Extended Coordinates
@@ -339,7 +346,7 @@ impl EdwardsPoint {
     pub fn double_and_add(&self, s: &Scalar) -> EdwardsPoint {
         let mut N = self.clone();
         let mut n = s.clone();
-        let mut Q = EdwardsPoint::zero();
+        let mut Q = EdwardsPoint::identity();
 
         while n != Scalar::zero() {
             if !n.is_even() {
@@ -442,5 +449,16 @@ pub mod tests {
         let res: EdwardsPoint = &P1 + &P1;
         
         assert!(res == P3);
+    }
+
+    #[test]
+    fn double_and_add() {
+        let res1 = &P1 * &Scalar::from(&2u8);
+
+        let res2 = &P1 + &P1;
+
+        let res3 = &P1.double();
+
+        println!("{:?}\n{:?}\n{:?}", res1, res2, res3);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,12 @@
 //! <a href="https://travis-ci.com/dusk-network/dusk-zerocaf">
 //! <img src="https://travis-ci.com/dusk-network/dusk-zerocaf.svg?branch=master" />
 //! </a>
+//! <a href="https://github.com/dusk-network/dusk-zerocaf">
+//! <img alt="GitHub closed issues" src="https://img.shields.io/github/issues-closed/dusk-network/dusk-zerocaf.svg?color=4C4CFF">
+//! </a>
+//! <a href="https://crates.io/crates/zerocaf">
+//! <img alt="Crates.io" src="https://img.shields.io/crates/v/zerocaf.svg?color=f07900">
+//! </a>
 //! </hr>
 //! 
 //! <div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,10 @@
 //! 
 //! // For optimized/release builds:
 //! cargo build --release --features "u64_backend"
-//! ```
+//! ``` 
+//! <br>
+//! 
+//! NOTE: If no backend is selected, compilation will fail!<br>
 //! 
 //! # Security and features of Zerocaf
 //! 
@@ -78,14 +81,13 @@
 //! By expounding the operations in this manner, we can benefit from the speed of a non-prime order twisted 
 //! edwards curve whilst not suffering the pitfalls of a cofactor greater than one.
 //! 
-//! NOTE: If no backend is selected, compilation will fail!<br>
 //! 
 //! # Performance & Benchmarks
 //! Benchmarks have been implemented using [Criterion.rs](https://docs.rs/criterion/0.2.11/criterion/).
 //! To run them just execute `cargo bech` on the repository root.<br>
 //! 
 //! All of the operatons have been implemented using bit-shifting techniques to allow a better performance
-//! and a decrease in execution time.  
+//! and a huge reduction on execution time.  
 
 
 // Used for traits related to constant-time code.

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -4,12 +4,10 @@
 //! A `MontgomeryPoint` is represented as the `u-coordinate`
 //! of itself in LE byte-format.
 
-use crate::edwards::{CompressedEdwardsY, EdwardsPoint};
+use crate::edwards::EdwardsPoint;
 use crate::field::FieldElement;
-use crate::scalar::Scalar;
 
 use subtle::Choice;
-use subtle::ConditionallySelectable;
 use subtle::ConstantTimeEq;
 
 /// Holds the u-coordinate of a point on the Montgomery form of
@@ -54,7 +52,7 @@ impl MontgomeryPoint {
 
     /// Attempt to convert to an `EdwardsPoint`, using the supplied
     /// choice of sign for the `EdwardsPoint`.
-    pub fn to_edwards(&self, sign: u8) -> Option<EdwardsPoint> {
+    pub fn to_edwards(&self, _sign: u8) -> Option<EdwardsPoint> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
Bump to version 0.1.1 on Crates.io

- Removed redundant tests.
- Removed Badges from `Cargo.toml`.
- Improved Point Operation algorithms.
- Refactored some documentation parts.
- Added Crates.io and Issue-tracking badges.

#### On Point Doubling:
Until we don't find which is the reason that
makes the algorithm fail (since it's implemented
as the pseudocode says on the `Twisted Edwards
Curves revisted` paper) point doubling will be
implemented as an addition of a point to itself.

This is also correct but forces us to perform 1M
and 1S extra. So we will work to solve it.