### PR TITLE
Allow compilation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ exclude = [
     "**/.gitignore",
     ".gitignore",
     "**/tools",
-    "**/sage_codes"
-
+    "**/sage_codes",
+    "**/examples/**.rs"
 ]
 license = "MIT"
 edition = "2018"
@@ -26,6 +26,7 @@ curve25519-dalek = "1.1.3"
 
 [dev-dependencies]
 criterion = "0.2"
+rand = "0.7.0"
 
 
 # Criterion benchmarks


### PR DESCRIPTION
Added `rand` as dev-dependency to allow examples compilation on `cargo test` command execution.

Excluded `examples/` folder from the crate uploaded to [Crates.io](https://www.crates.io).