### PR TITLE
Implement docs for field and scalar mods.

### DIFF
--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -382,7 +382,7 @@ impl FieldElement {
         res
     }
 
-    /// Given a `k`: u64, compute `2^k` giving the resulting result
+    /// Given a `k`: u64, compute `2^k` giving the result
     /// as a `FieldElement`.
     /// Note that the input must be between the range => 0..260.
     /// 

--- a/src/backend/u64/scalar.rs
+++ b/src/backend/u64/scalar.rs
@@ -359,6 +359,33 @@ impl Scalar {
         ]
     }
 
+    /// Given a `k`: u64, compute `2^k` giving the result
+    /// as a `Scalar`.
+    /// Note that the input must be between the range => 0..248.
+    pub fn two_pow_k(exp: &u64) -> Scalar {
+        let mut res = Scalar::zero();
+
+        debug_assert!(exp < &248u64);
+        match exp {
+            0...51 => {
+               res[0]  = 1u64 << exp;
+            },
+            52...103 => {
+                res[1] = 1u64 << (exp - 52);
+            },
+            104...155 => {
+                res[2] = 1u64 << (exp - 104);
+            },
+            156...207 => {
+                res[3] = 1u64 << (exp - 156);
+            },
+            _ => {
+                res[4] = 1u64 << (exp - 208);
+            }
+        }
+        res
+    }
+
     /// Compute `limbs/R` (mod l), where R is the Montgomery modulus 2^260
     #[inline]
     pub fn montgomery_reduce(limbs: &[u128; 9]) -> Scalar {
@@ -480,6 +507,12 @@ mod tests {
     /// `X * Y (mod l) = 890263784947025690345271110799906008759402458672628420828189878638015362081`
     pub static X_TIMES_Y: Scalar = Scalar([3414372756436001, 1500062170770321, 4341044393209371, 2791496957276064, 2164111380879]); 
 
+    /// `2^197 (mod l) = 200867255532373784442745261542645325315275374222849104412672`
+    pub static TWO_POW_197: Scalar = Scalar([0, 0, 0, 2199023255552, 0]);
+
+    /// `2^104 (mod l) = 20282409603651670423947251286016`
+    pub static TWO_POW_104: Scalar = Scalar([0, 0, 1, 0, 0]);
+
     #[test]
     fn partial_ord_and_eq() {
         assert!(Y.is_even());
@@ -584,6 +617,27 @@ mod tests {
         for i in 0..5 {
             assert!(a_half[i] == A.half()[i]);
             assert!(a_half_half[i] == A.half().half()[i]);
+        }
+    }
+
+    #[test]
+    fn two_pow_k() {
+        // Check for 0 value
+        let zero = Scalar::two_pow_k(&0u64);
+        for i in 0..5 {
+            assert!(zero[i] == Scalar::one()[i]);
+        }
+      
+        // Check for non 52-multiple `k` values
+        let non_multiple = Scalar::two_pow_k(&197u64);
+        for i in 0..5 {
+            assert!(non_multiple[i] == TWO_POW_197[i]);
+        }
+
+        // Check for 52-multiple `k` values
+        let non_multiple = Scalar::two_pow_k(&104u64);
+        for i in 0..5 {
+            assert!(non_multiple[i] == TWO_POW_104[i]);
         }
     }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -8,6 +8,55 @@
 //! here since they will be the samme across all of the different
 //! backends.
 
+
+//! # Examples
+//! ```rust
+//! use zerocaf::field::FieldElement;
+//! use zerocaf::traits::ops::*;
+//! use constants::EDWARDS_D;
+//! 
+//! // You can create a FieldElement from a byte-array as follows:
+//! let a = FieldElement::from_bytes(&[0u8;32]); 
+//! 
+//! // You ca also create a FieldElement from an uint type as follows:
+//! let b = FieldElement::from(&86649u128);
+//! let c = FieldElement::from(&86650u64);
+//! 
+//! // The last way of creating a FieldElement it by calling the
+//! // constructor. THIS IS NOT RECOMMENDED since ANY checks about
+//! // the correctness of the input will be done. It can be done as
+//! // follows: 
+//! let d: FieldElement = FieldElement([0, 1, 0, 0, 0]); // d = 2^52.
+//! assert!(d == FieldElement::two_pow_k(&52u64));
+//! 
+//! // All of the basuc modular operations are implemented 
+//! // for FieldElement type:  
+//! let mut res = &a + &b; // Performs a + b (mod l).
+//! res = &a - &b; // Performs a - b (mod l).
+//! res = &a * &b; // Performs a * b (mod l).
+//! res = &a.square(); // Performs a^2 (mod l).
+//! res = -&a; // Performs Negation over the modulo l.
+//! 
+//! // Division has been also implemented. Remember that when we write
+//! // a/b (mod l), we are indeed performing a * inverse_mod(b, l) (mod l).
+//! assert!(-&b / &d == EDWARDS_D);
+//! 
+//! // Dividing by two even FieldElements is recommended through the `Half`
+//! // trait implmementation since it's much faster.
+//! if a.is_even() {
+//!     let half_a = &a.half(); // This will panic if a isn't even.
+//! }
+//! 
+//! We can finally perform inversion modulo l for a FieldElement:
+//! let inv_a = &a.inverse(); // Performs a^-1 (mod l).
+//! ```
+//! 
+//! `PartialOrd`, `Ord`, `PartialEq` and `Eq` are also implemented for
+//! `FieldElement` type. 
+//! 
+//! All `std::core::ops traits -> (Add, Sub, Mul, Div)` are implemented
+//! bor both, `&FieldElement` and `FieldElement`.
+
 use core::cmp::PartialEq;
 
 use subtle::Choice;

--- a/src/field.rs
+++ b/src/field.rs
@@ -55,7 +55,7 @@
 //! `FieldElement` type. 
 //! 
 //! All `std::core::ops traits -> (Add, Sub, Mul, Div)` are implemented
-//! bor both, `&FieldElement` and `FieldElement`.
+//! for both, `&FieldElement` and `FieldElement`.
 
 use core::cmp::PartialEq;
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -13,7 +13,7 @@
 //! ```rust
 //! use zerocaf::field::FieldElement;
 //! use zerocaf::traits::ops::*;
-//! use constants::EDWARDS_D;
+//! use zerocaf::constants::EDWARDS_D;
 //! 
 //! // You can create a FieldElement from a byte-array as follows:
 //! let a = FieldElement::from_bytes(&[0u8;32]); 
@@ -23,9 +23,9 @@
 //! let c = FieldElement::from(&86650u64);
 //! 
 //! // The last way of creating a FieldElement it by calling the
-//! // constructor. THIS IS NOT RECOMMENDED since ANY checks about
-//! // the correctness of the input will be done. It can be done as
-//! // follows: 
+//! // constructor. THIS IS NOT RECOMMENDED since NO checks about
+//! // the correctness of the input will be done at all. 
+//! // It can be done as follows: 
 //! let d: FieldElement = FieldElement([0, 1, 0, 0, 0]); // d = 2^52.
 //! assert!(d == FieldElement::two_pow_k(&52u64));
 //! 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -12,6 +12,46 @@
 //! which is a type-alias for the curve25519-dalek Scalar Struct.
 //! 
 
+//! # Examples
+//! ```rust
+//! use zerocaf::scalar::Scalar;
+//! use zerocaf::traits::ops::*;
+//! 
+//! // You can create a Scalar from a byte-array as follows:
+//! let a = Scalar::from_bytes(&[0u8;32]); 
+//! 
+//! // You ca also create a Scalar from an uint type as follows:
+//! let b = Scalar::from(&86649u128);
+//! let c = Scalar::from(&86650u64);
+//! 
+//! // The last way of creating a Scalar it by calling the
+//! // constructor. THIS IS NOT RECOMMENDED since ANY checks about
+//! // the correctness of the input will be done. It can be done as
+//! // follows: 
+//! let d: Scalar = Scalar([0, 1, 0, 0, 0]); // d = 2^52.
+//! assert!(d == Scalar::two_pow_k(&52u64));
+//! 
+//! // All of the basuc modular operations are implemented 
+//! // for Scalar type:  
+//! let mut res = &a + &b; // Performs a + b (mod l).
+//! res = &a - &b; // Performs a - b (mod l).
+//! res = &a * &b; // Performs a * b (mod l).
+//! res = &a.square(); // Performs a^2 (mod l).
+//! res = -&a; // Performs Negation over the modulo l.
+//! 
+//! // Dividing by two even Scalars is recommended through the `Half`
+//! // trait implmementation since it's much faster.
+//! if a.is_even() {
+//!     let half_a = &a.half(); // This will panic if a isn't even.
+//! }
+//! ```
+//! 
+//! `PartialOrd`, `Ord`, `PartialEq` and `Eq` are also implemented for
+//! `Scalar` type. 
+//! 
+//! All `std::core::ops traits -> (Add, Sub, Mul)` are implemented
+//! for both, `&Scalar` and `Scalar`.
+
 use crate::backend;
 
 use subtle::Choice;


### PR DESCRIPTION
Both docs include examples about `how-to-use` the module on which they are declared.

Also implemented `two_pow_k()` for `&Scalar` with the correct maximum exponent value.